### PR TITLE
feat: remove mlcl_queue dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ node_js:
 before_install:
   - sudo rm -vf /etc/apt/sources.list.d/*riak*
   - sudo apt-get update
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.2.deb && sudo dpkg -i --force-confnew elasticsearch-6.2.2.deb && sudo service elasticsearch restart
 before_script:
   - sleep 30

--- a/index.ts
+++ b/index.ts
@@ -4,15 +4,16 @@ import { promisify } from 'util';
 
 class mlcl_elastic {
 
-  private static _instance:mlcl_elastic = null;
+  private static _instance: mlcl_elastic = null;
   public static molecuel;
-  public config:any;
+  public static models = new Map<string, any>();
+  public config: any;
   public connection: any;
   // @todo: Add mlcl_queue type here
   public queue: any;
 
   constructor() {
-    if(mlcl_elastic._instance){
+    if (mlcl_elastic._instance) {
       throw new Error("Error: Instantiation failed. Singleton module! Use .getInstance() instead of new.");
     }
 
@@ -21,12 +22,8 @@ class mlcl_elastic {
     // register on init function of core and create connection
     mlcl_elastic.molecuel.on('mlcl::core::init:post', (molecuel) => {
       this.config = molecuel.config.search;
-    });
-
-    mlcl_elastic.molecuel.on('mlcl::queue::init:post', (queue) => {
-      this.queue = queue;
       this.connect((err, connection) => {
-        if(err) {
+        if (err) {
           mlcl_elastic.molecuel.log.error('mlcl_elastic', 'Error while connecting' + err);
         } else {
           this.connection = connection;
@@ -35,10 +32,11 @@ class mlcl_elastic {
       });
     });
 
+
     // Schema creation event
     // this is used to register the plugin to the schema
     mlcl_elastic.molecuel.on('mlcl::database::registerModel:pre', (database, modelname, schema, options) => {
-      if(options.indexable) {
+      if (options.indexable) {
         //self.ensureIndex(modelname, function() {});
         options.modelname = modelname;
         schema.plugin(this.plugin, options);
@@ -49,48 +47,25 @@ class mlcl_elastic {
     mlcl_elastic.molecuel.on('mlcl::database::registerModel:post', async (database, modelname, model) => {
       // returns err and model
       mongolastic.registerModel(model, async (err) => {
-        if(err) {
+        if (err) {
           mlcl_elastic.molecuel.log.error('mlcl_elastic', 'Error while registering model to elasticsearch' + err);
         } else {
-          if (mlcl_elastic.molecuel.serverroles && mlcl_elastic.molecuel.serverroles.worker) {
-            var qname = 'mlcl__elastic__' + modelname + '_resync';
-            this.queue.ensureQueue(qname, (err) => {
-              if(!err) {
-                this.queue.client.createReceiver(qname).then((receiver) => {
-                  receiver.on('message', (msg) => {
-                    var id = msg.body.toString();
-                    if(id) {
-                      model.syncById(id, async (err) => {
-                        if(!err) {
-                          receiver.accept(msg);
-                        } else {
-                          mlcl_elastic.molecuel.log.error('mlcl_elastic', err);
-                          receiver.release(msg);
-                        }
-                      });
-                    }
-                  });
-                }).error((qerr) => {
-                  mlcl_elastic.molecuel.log.error('mlcl_elastic', qerr);
-                });
-              } else {
-                mlcl_elastic.molecuel.log.error('mlcl_elastic', err);
-              }
-            })
+          if (!mlcl_elastic.models.has(modelname)) {
+            mlcl_elastic.models.set(modelname, model);
           }
         }
       });
     });
   }
 
-  public static getInstance():mlcl_elastic {
-    if(mlcl_elastic._instance === null) {
+  public static getInstance(): mlcl_elastic {
+    if (mlcl_elastic._instance === null) {
       mlcl_elastic._instance = new mlcl_elastic();
     }
     return mlcl_elastic._instance;
   }
 
-  public static init(m):mlcl_elastic {
+  public static init(m): mlcl_elastic {
     mlcl_elastic.molecuel = m;
     return mlcl_elastic.getInstance();
   }
@@ -99,14 +74,14 @@ class mlcl_elastic {
    * Connect the instance to elastic
    * @param callback
    */
-  public connect(callback: Function):void {
+  public connect(callback: Function): void {
     mongolastic.connect(this.config.prefix, this.config, callback);
   }
 
-  public ensureIndex (modelname: string, callback: Function):void {
+  public ensureIndex(modelname: string, callback: Function): void {
     //check if index already exists
     mongolastic.indices.exists((modelname, err, exists: boolean) => {
-      if(!exists) {
+      if (!exists) {
         //@todo: get specific mapping information from model definition or central config?
         var mappings: { [index: string]: any; } = {};
         mappings[modelname] = {
@@ -136,7 +111,7 @@ class mlcl_elastic {
         };
         var settings = {}; //@todo: make settings configurable from model definition or central config?
         mongolastic.indices.create(modelname, settings, mappings, (err) => {
-          if(err) {
+          if (err) {
             mlcl_elastic.molecuel.log.error('mlcl_elastic', 'Error while creating indices' + err);
           }
         });
@@ -147,7 +122,7 @@ class mlcl_elastic {
     });
   }
 
-  public index(modelname: String, entry: any, callback:Function):void {
+  public index(modelname: String, entry: any, callback: Function): void {
     mongolastic.index(modelname, entry, callback);
   }
 
@@ -155,7 +130,7 @@ class mlcl_elastic {
    * Delete Index from elasticsearch
    * @param callback
    */
-  public delete(modelname:String, entry:any, callback: Function): void {
+  public delete(modelname: String, entry: any, callback: Function): void {
     mongolastic.delete(modelname, entry, callback);
   }
 
@@ -177,36 +152,30 @@ class mlcl_elastic {
     mongolastic.sync(model, modelname, callback);
   }
 
-  public resync(modelname: string, query: any): void  {
+  public resync(modelname: string, query: any): void {
     var elast = mlcl_elastic.getInstance();
-    var dbmodel:any = this;
-    if(modelname) {
-      const queuename = 'mlcl__elastic_resync';
-      elast.queue.ensureQueue(queuename, (err) => {
-        if(!err) {
-          elast.queue.client.createSender(queuename).then((sender) => {
-            var count = 0;
-            var stream = dbmodel.find(query,'_id').lean().stream();
-      
-            stream.on('error', function (err) {
-              // handle err
-              mlcl_elastic.molecuel.log.error('mlcl_elastic', err);
-            });
-      
-            stream.on('data', (obj:any) => {
-              count++;
-              sender.send({id: obj._id.toString(), model: modelname});
-            });
-          
-            stream.on('end', function() {
-              mlcl_elastic.molecuel.log.info('mlcl_elastic', 'reindex for '+modelname+' has been added to queue, ' + count + 'items');
-            });
-          }).error((err) => {
+    var dbmodel: any = this;
+    if (modelname) {
+      var count = 0;
+      var stream = dbmodel.find(query, '_id').lean().stream();
+
+      stream.on('error', function (err) {
+        // handle err
+        mlcl_elastic.molecuel.log.error('mlcl_elastic', err);
+      });
+
+      stream.on('data', (obj: any) => {
+        mongolastic.syncById(mlcl_elastic.models.get(modelname), modelname, obj._id.toString(), (err) => {
+          if (!err) {
+            count++;
+          } else {
             mlcl_elastic.molecuel.log.error('mlcl_elastic', err);
-          })
-        } else {
-          mlcl_elastic.molecuel.log.error('mlcl_elastic', err);
-        }
+          }
+        });
+      });
+
+      stream.on('end', function () {
+        mlcl_elastic.molecuel.log.info('mlcl_elastic', 'reindex for ' + modelname + ' is running, ' + count + 'items');
       });
     }
   }
@@ -216,17 +185,17 @@ class mlcl_elastic {
    * @param query
    * @param callback
    */
-   public search(query: any, callback: Function):void {
-     var elast = mlcl_elastic.getInstance();
-     if(query && query.index) {
-       //rewrite index
-       var i = query.index.split(',');
-       query.index = i.map(function(index) {
-         return elast.getIndexName(index);
-       }).join(',');
-     }
-     mongolastic.search(query, callback);
-   }
+  public search(query: any, callback: Function): void {
+    var elast = mlcl_elastic.getInstance();
+    if (query && query.index) {
+      //rewrite index
+      var i = query.index.split(',');
+      query.index = i.map(function (index) {
+        return elast.getIndexName(index);
+      }).join(',');
+    }
+    mongolastic.search(query, callback);
+  }
 
   /**
    * Gets a entry by url and language
@@ -238,17 +207,17 @@ class mlcl_elastic {
       body: {
         from: 0,
         size: 1,
-        query : {
+        query: {
           bool: {
             filter: {
               term: {
                 url: url
-              }  
+              }
             },
             should: [
               {
-                term : {
-                  lang : lang
+                term: {
+                  lang: lang
                 }
               },
               {
@@ -272,13 +241,13 @@ class mlcl_elastic {
    * @param id
    * @param callback
    */
-  public searchById(id: Number, callback: Function):void {
+  public searchById(id: Number, callback: Function): void {
     mlcl_elastic.getInstance().search({
       body: {
         query: {
-            term : {
-              _id : id
-            }
+          term: {
+            _id: id
+          }
         }
       }
     }, callback);
@@ -292,7 +261,7 @@ class mlcl_elastic {
    * @param callback
    * @see http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-indices-exists
    */
-  public exists(indexname: string, callback: Function):void {
+  public exists(indexname: string, callback: Function): void {
     this.connection.indices.exists({
       index: this.getIndexName(indexname),
     }, callback);
@@ -308,7 +277,7 @@ class mlcl_elastic {
    * @param callback
    * @see http://www.elasticsearch.org/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-indices-create
    */
-   public create(indexname, settings, mappings, callback) {
+  public create(indexname, settings, mappings, callback) {
     var elast = mlcl_elastic.getInstance();
     elast.connection.indices.create({
       index: elast.getIndexName(indexname),
@@ -327,8 +296,8 @@ class mlcl_elastic {
    */
   public checkCreateIndex(indexname, settings, mappings, callback) {
     var elast = mlcl_elastic.getInstance();
-    elast.exists(indexname, function(err, response) {
-      if(!response) {
+    elast.exists(indexname, function (err, response) {
+      if (!response) {
         elast.create(indexname, settings, mappings, function (err) {
           callback(err, true);
         });
@@ -375,8 +344,8 @@ class mlcl_elastic {
    */
   public getIndexName(name: string) {
     var elast = mlcl_elastic.getInstance();
-    if(elast.config.prefix) {
-      if(name.indexOf(elast.config.prefix+'-') === 0) {
+    if (elast.config.prefix) {
+      if (name.indexOf(elast.config.prefix + '-') === 0) {
         return name.toLowerCase();
       } else {
         return elast.config.prefix + '-' + name.toLowerCase();
@@ -387,4 +356,8 @@ class mlcl_elastic {
   }
 }
 
-export = mlcl_elastic.init;
+function init(m) {
+  return mlcl_elastic.init(m);
+};
+
+export = init;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "mlcl_elastic",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "dependencies": {
     "async": "^0.9.0",
-    "mlcl_queue": ">=1.1.0",
     "mongolastic": ">=0.6.0"
   },
   "engines": {
@@ -21,7 +20,7 @@
     "@types/node": "^9.4.6",
     "assert": ">=0.0.1",
     "mlcl_database": ">=0.0.1",
-    "mocha": "*",
+    "mocha": "<=7.1.1",
     "mocha-jshint": ">=0.0.1",
     "mongoose": ">=0.0.1",
     "should": ">= 0.0.1"

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,6 @@ var should = require('should'),
     util = require('util'),
     EventEmitter = require('events').EventEmitter,
     mlcl_database = require('mlcl_database'),
-    mlcl_queue = require('mlcl_queue'),
     mlcl_elastic = require('../');
 
 describe('mlcl_elastic', function() {
@@ -45,7 +44,6 @@ describe('mlcl_elastic', function() {
 
         mongo = mlcl_database(molecuel);
         mlcl_elastic(molecuel);
-        mlcl_queue(molecuel);
 
         testobjEn = {
             '_id': '98098098',


### PR DESCRIPTION
Schau es dir bitte mal kritisch an, primär sind durch das entfernen von mlcl_queue das Startup und der resync betroffen;
es wurde präventiv die elasticsearch Version für travis auf 6.2.2 fixiert, hier stellt sich noch die Frage ob man Tests etc direkt in eine github Action umverfrachtet...